### PR TITLE
Show explanation for badge request only conditionally

### DIFF
--- a/resources/views/profile-form.blade.php
+++ b/resources/views/profile-form.blade.php
@@ -133,13 +133,6 @@
             method="post"
             heading="Verification"
         >
-            <p class="mb-2 text-font">
-                Please let us know if you're a PHP internal developer or an RFC Vote contributor by filling in this form. Verified users will get a badge before their username.
-            </p>
-            <p class="mb-4 text-font">
-                If you're not an internal developer or RFC Vote contributor, but would still like a badge, you can also fill in the form to explain why: we might add other types of badges in the future.
-            </p>
-
             @if($user->flair)
                 <div class="flex gap-2 items-baseline">
                     <p class="text-green-600 font-bold">Your current badge:</p>
@@ -147,6 +140,13 @@
                     <x-profile.flair :user="$user"/>
                 </div>
             @elseif($user->pendingVerificationRequests->isEmpty())
+                <p class="mb-2 text-font">
+                    Please let us know if you're a PHP internal developer or an RFC Vote contributor by filling in this form. Verified users will get a badge before their username.
+                </p>
+                <p class="mb-4 text-font">
+                    If you're not an internal developer or RFC Vote contributor, but would still like a badge, you can also fill in the form to explain why: we might add other types of badges in the future.
+                </p>
+
                 <div class="space-y-3">
                     <x-form.textarea name="motivation" label="Motivation" rows="5"></x-form.textarea>
 


### PR DESCRIPTION
This text only makes sense if the form is shown. Therefore, move it to only show it conditionally.